### PR TITLE
feat: declare support for symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^8.0",
     "doctrine/orm": "^2.13",
-    "symfony/uid": "^5.3"
+    "symfony/uid": "^5.3 || ^6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Allow for `symfony/uid` to be `^6.0` as well.