### PR TITLE
chore: update phpunit to version 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.5 | ^10.0",
     "symplify/easy-coding-standard": "^11.1",
     "phpstan/phpstan": "^1.8"
   }


### PR DESCRIPTION
PHPUnit 10 dropped support for php8.0, therefore we need to also support 9.5 for now.